### PR TITLE
Removing socket connection from constructor

### DIFF
--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/Transport/UnixDomainSocketDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/Transport/UnixDomainSocketDataTransport.cs
@@ -74,9 +74,9 @@ internal class UnixDomainSocketDataTransport : IDataTransport, IDisposable
     {
         this.socket.Dispose();
     }
-
-    private void Connect()
+    private void Reconnect()
     {
+        this.socket.Close();
         try
         {
             this.CreateSocket();
@@ -86,17 +86,9 @@ internal class UnixDomainSocketDataTransport : IDataTransport, IDisposable
         {
             ExporterEventSource.Log.ExporterException("UDS Connect failed.", ex);
 
-            // Re-throw the exception to
-            // 1. fail fast in Geneva exporter contructor, or
-            // 2. fail in the Reconnect attempt.
+            // Re-throw the exception to fail in the Reconnect attempt.
             throw;
         }
-    }
-
-    private void Reconnect()
-    {
-        this.socket.Close();
-        this.Connect();
     }
 
     private void CreateSocket()

--- a/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/Transport/UnixDomainSocketDataTransport.cs
+++ b/src/OpenTelemetry.Exporter.Geneva/MsgPackExporter/Transport/UnixDomainSocketDataTransport.cs
@@ -43,7 +43,7 @@ internal class UnixDomainSocketDataTransport : IDataTransport, IDisposable
     {
         this.unixEndpoint = new UnixDomainSocketEndPoint(unixDomainSocketPath);
         this.timeoutMilliseconds = timeoutMilliseconds;
-        this.Connect();
+        this.CreateSocket();
     }
 
     public bool IsEnabled()
@@ -79,10 +79,7 @@ internal class UnixDomainSocketDataTransport : IDataTransport, IDisposable
     {
         try
         {
-            this.socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP)
-            {
-                SendTimeout = this.timeoutMilliseconds,
-            };
+            this.CreateSocket();
             this.socket.Connect(this.unixEndpoint);
         }
         catch (Exception ex)
@@ -100,5 +97,13 @@ internal class UnixDomainSocketDataTransport : IDataTransport, IDisposable
     {
         this.socket.Close();
         this.Connect();
+    }
+
+    private void CreateSocket()
+    {
+        this.socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP)
+        {
+            SendTimeout = this.timeoutMilliseconds,
+        };
     }
 }


### PR DESCRIPTION
## Changes
Skip the socket connection while creating the socket so that the sdk wont fail fast. The socket connection will be made only during a reconnect. 
